### PR TITLE
Update to allow for standard require statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.10.3",
   "description": "TeX to MathML conversion in JavaScript.",
   "main": "dist/temml.js",
+  "exports": {
+    ".": {
+      "require": "./dist/temml.cjs"
+    },
+    "./*": "./*"
+  },
   "homepage": "https://temml.org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Unlike previous patch, this conforms to your current setup so that jsDelivr will work. This simply tells node to look for the `cjs` when using a require statement.  Since there's no umd, there's no need for an `import` detail.