### PR TITLE
Use DIAMETER SIGN instead of LETTER O WITH STROKE for \varnothing

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -556,7 +556,7 @@ defineSymbol(math, open, "\u00ac", "\\lnot");
 defineSymbol(math, textord, "\u22a4", "\\top");
 defineSymbol(math, textord, "\u22a5", "\\bot");
 defineSymbol(math, textord, "\u2205", "\\emptyset");
-defineSymbol(math, textord, "\u00f8", "\\varnothing");
+defineSymbol(math, textord, "\u2300", "\\varnothing");
 defineSymbol(math, mathord, "\u03b1", "\\alpha", true);
 defineSymbol(math, mathord, "\u03b2", "\\beta", true);
 defineSymbol(math, mathord, "\u03b3", "\\gamma", true);


### PR DESCRIPTION
I believe this is the symbol that `amssymb` uses for `\varnothing`: [U+2300](https://www.fileformat.info/info/unicode/char/2300/index.htm). At least that's what I conclude from this: https://milde.users.sourceforge.net/LUCR/Math/mathpackages/amssymb-symbols.pdf