### PR TITLE
Fix handling of empty superscripts and subscripts

### DIFF
--- a/test/unit-test.cjs
+++ b/test/unit-test.cjs
@@ -2353,6 +2353,13 @@ const test = () => {
   new Expect(build(wrapExpression, wrapSettings("="))[0].children.length).toBe(2)
   new Expect(build(r`x^{\textcolor{red}{-yz}}`)[0].children.length).toBe(2)
 
+  assertion = "Empty super and subscripts should work"
+  new Expect("x^{}").toBuild();
+  new Expect("x^{}_{}").toBuild();
+  new Expect("x^{}_2").toBuild();
+  new Expect("x^2_{}").toBuild();
+  new Expect("x_{}").toBuild();
+
   console.log("Number of tests:    " + numTests)
   console.log("Number of failures: " + numFailures)
 }

--- a/utils/temml.cjs
+++ b/utils/temml.cjs
@@ -7631,7 +7631,7 @@ defineFunctionBuilders({
     if (group.sup) {
       const sup = buildGroup$1(group.sup, childStyle);
       const testNode = sup.type === "mrow" ? sup.children[0] : sup;
-      if ((testNode.type === "mo" && testNode.classes.includes("tml-prime"))
+      if ((testNode && testNode.type === "mo" && testNode.classes.includes("tml-prime"))
         && group.base && group.base.text && group.base.text === "f") {
         // Chromium does not address italic correction on prime. Prevent f′ from overlapping.
         testNode.classes.push("prime-pad");


### PR DESCRIPTION
Temml raised an exception when I fed it an equation containing an empty superscript, e.g. $x^{}$. Its a weird but valid bit of LaTeX math.

The problem arose in some code that's directed at working around a Chromium bug in temml.cjs:7634. It attempts to look at the first child in a superscript to see if it needs to apply the fix. But if the superscript is empty, there is no first element. I added a check for an empty superscript here