### PR TITLE
Add missing backslash in `supported.md`

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -715,7 +715,8 @@ Temml has no `\par`, so `\long` is ignored.
 +----------------------+--------------------------+-----------------------------+-------------------------------+
 | $\oiiint$  `\oiiint` | $\intlarhk$  `\intlarhk` | $\sqint$  `\sqint`          | $\intx$  `\intx`              |
 +----------------------+--------------------------+-----------------------------+-------------------------------+
-| $\intbar$  `\intbar` | $\intBar$  `\intBar`     | $\fint$  `\fint`            | $\bigdoublevee$ `bigdoublevee`|
+| $\intbar$  `\intbar` | $\intBar$  `\intBar`     | $\fint$  `\fint`            | $\bigdoublevee$               |
+|                      |                          |                             | `\bigdoublevee`               |
 +----------------------+--------------------------+-----------------------------+-------------------------------+
 | $\intcup$  `\intcup` | $\intclockwise$          | $\bigtimes$ `\bigtimes`     | $\bigdoublewedge$             |
 |                      | `\intclockwise`          |                             | `\bigdoublewedge`             |


### PR DESCRIPTION
There is also something wrong with the rendering, because these are not the right symbols:

![image](https://github.com/user-attachments/assets/f65d6efe-f37e-4179-8e9a-29d000f07e0e)
