### PR TITLE
Fix type definitions

### DIFF
--- a/temml.d.ts
+++ b/temml.d.ts
@@ -4,7 +4,7 @@ export interface Options {
   leqno?: boolean;
   throwOnError?: boolean;
   errorColor?: string;
-  macros?: Record<string, string>;
+  macros?: Record<string, any>;
   wrap?: "tex" | "=" | "none";
   xml?: boolean;
   colorIsTextColor?: boolean;
@@ -16,7 +16,7 @@ export interface Options {
 
 export function render(
   expression: string,
-  baseNode: HTMLElement,
+  baseNode: HTMLElement | MathMLElement,
   options?: Options,
 ): void;
 


### PR DESCRIPTION
- Base in render options accepts either a MathMLElement or an HTMLElement
- Macros are a record of string and tokens