### PR TITLE
Fix noto sans mathscr

### DIFF
--- a/dist/Temml-NotoSans.css
+++ b/dist/Temml-NotoSans.css
@@ -37,7 +37,7 @@ math {
 math.tml-display { display: block; }
 
 math .mathscr {
-  font-family: "ssty1";
+  font-feature-settings: "ssty";
 }
 
 *.mathcal {

--- a/temml.d.ts
+++ b/temml.d.ts
@@ -4,7 +4,7 @@ export interface Options {
   leqno?: boolean;
   throwOnError?: boolean;
   errorColor?: string;
-  macros?: Record<string, string>;
+  macros?: Record<string, any>;
   wrap?: "tex" | "=" | "none";
   xml?: boolean;
   colorIsTextColor?: boolean;
@@ -16,7 +16,7 @@ export interface Options {
 
 export function render(
   expression: string,
-  baseNode: HTMLElement,
+  baseNode: HTMLElement | MathMLElement,
   options?: Options,
 ): void;
 


### PR DESCRIPTION
The noto sans stylesheet overwrites the font-family in mathscr font. It probably meant to set the `font-feature-settings` instead.