### PR TITLE
fix mistaken payload in smallmatrix parsing

### DIFF
--- a/src/environments/array.js
+++ b/src/environments/array.js
@@ -794,9 +794,8 @@ defineEnvironment({
     numArgs: 0
   },
   handler(context) {
-    const payload = { type: "small" };
+    const payload = { envClasses: ["small"] };
     const res = parseArray(context.parser, payload, "script");
-    res.envClasses = ["small"];
     return res;
   },
   mathmlBuilder


### PR DESCRIPTION
for the payload used in parseArray: don't include the unrecognized `type`, include `envClasses`, and don't manually set it in the result.

(found this while upgrading to rollup 4.34 which drops unused props)