### PR TITLE
fix: Spelling mistake at supported page

### DIFF
--- a/docs/supported.md
+++ b/docs/supported.md
@@ -1488,13 +1488,13 @@ In cases where math fonts do not have a bold glyph, `\pmb` can simulate one. For
 | $\text{\textasciitilde}$           | $\dotso$  `\dotso`                 | $\ddagger$  `\ddagger` or `\ddag`  |
 | `\text{\textasciitilde}`           |                                    |                                    |
 +------------------------------------+------------------------------------+------------------------------------+
-| $\text{\textasciicircum}$          | $\dotsi$  `\idotsin`               | $\text{\textdaggerdbl}$            |
+| $\text{\textasciicircum}$          | $\dotsi$  `\idotsint`              | $\text{\textdaggerdbl}$            |
 | `\text{\textasciicircum}`          |                                    | `\text{\textdaggerdbl}`            |
 +------------------------------------+------------------------------------+------------------------------------+
 | \$ ``` $     `` ``` \`\`           | $\mathellipsis$ `\mathellipsis`    | $\angle$  `\angle`                 |
 +------------------------------------+------------------------------------+------------------------------------+
 | $\text{\textquoteleft}$            | $\text{\textellipsis}$             | $\measuredangle$  `\measuredangle` |
-| `text{\textquoteleft}`             | `\text{\textellipsis}`             |                                    |
+| `\text{\textquoteleft}`            | `\text{\textellipsis}`             |                                    |
 +------------------------------------+------------------------------------+------------------------------------+
 | $\lq$  `\lq`                       | $\Box$  `\Box`                     | $\sphericalangle$                  |
 |                                    |                                    | `\sphericalangle`                  |


### PR DESCRIPTION
Fixes #123

Corrects two typos in `docs/supported.md`. The command `\idotsin` was missing its trailing `t` (correct form is `\idotsint`), and the code example `` `text{\textquoteleft}` `` was missing the leading backslash. Both were documentation-only copy errors with no logic changes. Verified by visual inspection of the rendered markdown table in `docs/supported.md`.