### PR TITLE
Add TrustContext type to TypeScript definitions

### DIFF
--- a/temml.d.ts
+++ b/temml.d.ts
@@ -1,3 +1,10 @@
+export type TrustContext =
+  | { command: "\\class"; class: string }
+  | { command: "\\id"; id: string }
+  | { command: "\\style"; style: string }
+  | { command: "\\data"; attributes: Record<string, string> }
+  | { command: "\\includegraphics"; url: string; protocol?: string };
+
 export interface Options {
   displayMode?: boolean;
   annotate?: boolean;
@@ -9,7 +16,7 @@ export interface Options {
   xml?: boolean;
   colorIsTextColor?: boolean;
   strict?: boolean;
-  trust?: boolean | ((context: any) => boolean);
+  trust?: boolean | ((context: TrustContext) => boolean);
   maxSize?: [number, number];
   maxExpand?: number;
 }


### PR DESCRIPTION
Thank you for a very useful library!

This PR replaces the `any` type in the `trust` option callback with a proper discriminated union `TrustContext` type covering all supported commands (`\class`, `\id`, `\style`, `\data`, `\includegraphics`).

The type name and definition mirrors KaTeX's `TrustContext` type: https://github.com/KaTeX/KaTeX/blob/main/types/katex.d.ts